### PR TITLE
Improve tag merging when conflating

### DIFF
--- a/docs/highways.md
+++ b/docs/highways.md
@@ -282,7 +282,11 @@ Unfortunately manually validating the data is very time consuming, but
 it's important to get it right. I use the *TODO* plugin and also a
 data filter so I just select highways. With the TODO plugin, I add the
 selected features, ideally the entire task. Then I just go through all
-the features one at a time.
+the features one at a time. When the OSM XML dataset is loaded,
+nothing will appear in JOSM. This is because the OSM XML file produced
+by conflation has the refs for the way, but lack the nodes. All it
+takes is selecting the *update modified* menu itm under the *File*
+menu and all the nodes get downloaded, and the highways appear.
 
 I often have the original datasets loaded as layers, since sometimes
 it's useful to refer back to when you find issues with the

--- a/docs/highways.md
+++ b/docs/highways.md
@@ -36,7 +36,8 @@ Although most of the fields in these datasets aren't useful for OSM,
 some are like is it a seasonal road, various off road vehicle access
 permissions, etc... since this is also useful for navigation. Any tags
 added or edited will follow the [OSM Tagging
-Guidelines](https://wiki.openstreetmap.org/wiki/United_States_roads_tagging#Tagging_Forest_Roads)
+Guidelines](https://wiki.openstreetmap.org/wiki/United_States_roads_tagging#Tagging_Forest_Roads)lh
+
 for forest roads.
 
 # The Datasets
@@ -57,6 +58,8 @@ in the past, so it's relatively easy to match the
 geometries. Conflation then is mostly working through the name and
 reference fields between multiple files, which sometimes don't agree
 on the proper name.
+
+And OpenStreetMap of course.
 
 ## Processing The Datasets
 
@@ -112,10 +115,72 @@ clipped properly at the boundary. These task boundary polygons can
 then be used to create the project in the Tasking Manager, which will
 furthur split that into the size you want for mapping.
 
+### The OpenStreetMap Extract
+
+This step is unnecessary if you plan to manually conflate with a
+GeoJson file, so jump ahead to the next section.
+
+To conflate against OSM data with the goal of automatically merging
+the tags into the feature you have to prepare the dataset. Each
+feature needs to be validated anyway, merging tags is more efficient
+than cut & paste. Since this project is processing data from multiple
+US states, it exceeds the [Overpass](https://overpass-turbo.eu/) data
+size.
+
+I download the states I want to conflate from
+[Geofabrik](http://download.geofabrik.de/north-america.html), and then
+use [osmium
+merge](https://docs.osmcode.org/osmium/latest/osmium-merge.html) to
+turn it into one big file. I have to do this because most of the
+national forest cross state lines. You'll get duplicate ID errors if
+you download these files on different days, so grab all the ones you
+plan to merge at the same time. Geofabrik updates every 24 hours. When
+dealing with files too large for JOSM or QGIS,
+[osmium](https://osmcode.org/osmium-tool/) is the tool to use. There
+is also [osmfilter](https://wiki.openstreetmap.org/wiki/Osmfilter) and
+[osmconvert](https://wiki.openstreetmap.org/wiki/Osmconvert) which can
+be used as well. [Ogr2ogr](https://gdal.org/programs/ogr2ogr.html)
+can't be used as it can't write the OSM XML format. To merge multiple
+files with osmium, do this:
+
+	osmium merge --overwrite -o outdata.osm *.osm.pbf
+  
+The next step is to delete everything but highways from the OSM XML
+file. When conflating highways, we don't care about amenities or
+waterways.
+
+	osmium tags-filter --overwrite --remove-tags -o outdata.osm indata.osm w/highway=track,service,unclassified,primary,tertiary,secondary,path,residential,abandoned,footway,motorway,trunk
+
+Finally I clip this large file into separate datasets, one for each
+national forest.
+
+	osmium extract --overwrite --polygon boundary.geojson -o outdata-roads.osm 
+
 Then the real fun starts after the drudgery of getting ready to do
 conflation.
 
 ![Blank Sign](images/20200726_103229.jpg){width=300 height=200}
+
+#### Forest Road Names
+
+The names and reference number in OSM now have a wide variety of
+[incorrect
+tagging](https://wiki.openstreetmap.org/wiki/United_States_roads_tagging#National_Forest_Road_System)
+when it comes to names. *"Forest Service Road 123.4A"* is not a name,
+it is a reference number. Same for *"County Road 43"*.  The
+[fixname.py](https://github.com/hotosm/osm-merge/blob/tagging/utilities/fixnames.py)
+utility scan the OSM extract and when it see incorrect tagging,
+correct it to the OSM standard. Since the external datasets already
+follow the same guidelines, this increases the chance of a good match
+when conflating, since comparing names is part of the process.
+
+#### TIGER Tag Deletion
+
+Since there is community consensus that the *tiger:* tags added back
+in 2008 when the TIGER data was imported are meaningless, so should be
+deleted as bloat. The *fixnames.py* utility used for correct the name
+alos deletes these from each feature so you don't have to manually do
+it.
 
 ### MVUM Roads
 
@@ -232,9 +297,24 @@ the JOSM validators find many existing issues. I fix anything that is
 an error, and mostly ignore all the warning as that's a whole other
 project.
 
-There are two primary ways to validate the conflation
-output. Depending on the amount of data, sometimes one way is better
-than the other, so it's good to be flexible.
+If you are editing with the OSM XML file produced by conflation, when
+the file is opened, there will be some conflicts. This is usually due
+to things like the incorrect forest road name getting deleted, since
+now it's a proper *ref:usfs* reference number. And the tiger tags are
+gone as well if the *fixnames.py* utility is used. To fix the
+conflicts, I just select them all, and click on *resolve to my
+version*. Then I load all the ways into the
+[TODO](https://wiki.openstreetmap.org/wiki/JOSM/Plugins/TODO_list)
+plugin.
+
+Usng the plugin to validate a feature all I have to do is click on the
+entry. Sometimes there will be issues that need to be manually
+fixed. If conflation has changed the name, the old one is still in the
+feature so a manual comparison can be done. Sometimes there are weird
+typos that have slipped through the process. But many times for these
+remote highways you can just mark it as done, and go on to the next
+one. This lkets you validate a large number of features relatively
+quickly without sacrifing quality.
 
 #### Editing OSM XML
 
@@ -245,10 +325,11 @@ initially visible. If you go to the File menu, go down and execute
 *update modified*. This will download all the nodes for the ways, and
 all the highways will become visible. Highways that have multiple tags
 already in OSM will become a conflict. These can be resolved easier in
-JOSM using the conflict dialog box. No geometries have change, just
+JOSM using the conflict dialog box. No geometries have changed, just
 tags, so you have to manually select the tags to be merged. Features
 without tags beyond **highway=something** merge automatically. which
-makes validating these features quick and easy.
+makes validating these features quick and easy. Note that every
+feature needs to be validated indivigually.
 
 #### Editing GeoJson
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -56,3 +56,16 @@ Map](https://prd-tnm.s3.amazonaws.com/index.html?prefix=StagedProducts/TopoMapVe
 use the Shapefiles, as the different categories are in separate files
 inside the zip. Each one covers a 7.5 quad square on a topo map. These
 have to be merged together into a single file to be practical.
+
+## fixnames.py
+
+On the OSM wiki, there is a list of [incorrect
+tagging](https://wiki.openstreetmap.org/wiki/United_States_roads_tagging#National_Forest_Road_System)
+for forest highway names. Basically the name shouldn't be something
+like *"Forest Service Road 123.4A"*. That's actually a reference
+number, not a name. This is primarily a problem with existing OSM
+data. These would all have to get manually fixed when validating in
+JOSM, so this program automates the process so you only have to
+validate, and not edit the feature. After conflation, process the
+output file with this utility to produce an improved version.
+

--- a/utilities/fixnames.py
+++ b/utilities/fixnames.py
@@ -1,0 +1,272 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2021, 2022, 2023, 2024 Humanitarian OpenStreetMap Team
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    
+import argparse
+import logging
+import sys
+import os
+import re
+from sys import argv
+from osm_fieldwork.osmfile import OsmFile
+from geojson import Point, Feature, FeatureCollection, dump, Polygon, load
+import geojson
+from shapely.geometry import shape, LineString, Polygon, mapping
+import shapely
+from shapely.ops import transform
+from shapely import wkt
+from progress.bar import Bar, PixelBar
+from progress.spinner import PixelSpinner
+from osm_fieldwork.osmfile import OsmFile
+from osm_fieldwork.parsers import ODKParsers
+import pyproj
+import asyncio
+from codetiming import Timer
+import concurrent.futures
+from cpuinfo import get_cpu_info
+from time import sleep
+from haversine import haversine, Unit
+from thefuzz import fuzz, process
+from pathlib import Path
+from osm_fieldwork.parsers import ODKParsers
+from pathlib import Path
+from spellchecker import SpellChecker
+from osm_rawdata.pgasync import PostgresClient
+from tqdm import tqdm
+import tqdm.asyncio
+import xmltodict
+import math
+from threading import Thread
+
+# Instantiate logger
+log = logging.getLogger(__name__)
+
+# The number of threads is based on the CPU cores
+info = get_cpu_info()
+# Try doubling the number of cores, since the CPU load is
+# still reasonable.
+cores = info['count']
+
+
+async def main():
+    """This main function lets this class be run standalone by a bash script"""
+    parser = argparse.ArgumentParser(
+        prog="fix names",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+    parser.add_argument("-o", "--outfile", default="out.geojson", help="Output file from the conflation")
+    parser.add_argument("-i", "--infile", required=True, help="Input file to fix")
+
+    args = parser.parse_args()
+
+    # if verbose, dump to the terminal.
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+        ch = logging.StreamHandler(sys.stdout)
+        ch.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(
+            "%(threadName)10s - %(name)s - %(levelname)s - %(message)s"
+        )
+        ch.setFormatter(formatter)
+        log.addHandler(ch)
+
+    path = Path(args.infile)
+    if path.suffix == ".geojson":
+        file = open(args.infile, "r")
+        indata = geojson.load(file)
+        data = indata["features"]
+        file.close()
+    elif path.suffix == ".osm":
+        osm = OsmFile()
+        indata = osm.loadFile(args.infile)
+        data = indata
+    else:
+        log.error("Unsupport file type!")
+
+    features = list()
+    for feature in data:
+        tags = {"name": None, "ref:usfs": None, "ref": None}
+        matched = False
+        name = None
+        ref = None
+        if "properties" in feature:
+            if "name" in feature["properties"]:
+                name = feature["properties"]["name"]
+            else:
+                continue
+            if "ref" in feature["properties"]:
+                ref = feature["properties"]["ref"]
+        elif "tags" in feature:
+            if "name" in feature["tags"]:
+                name = feature["tags"]["name"]
+            if "ref" in feature["tags"]:
+                ref = feature["tags"]["ref"]
+
+        if ref is not None:
+            if ref.find(';') > 0:
+                tmp = ref.split(';')
+                log.debug(f"REF: {ref}")
+                tags["ref"] = tmp[0]
+                tags["ref:usfs"] = tmp[1]
+
+        if name is None:
+            continue
+
+        # log.debug(f"NAME: {name}")
+
+        # if name == "415.3A":
+        #    breakpoint()
+        ref = "[0-9]+[.a-z]"
+        pat = re.compile(ref)
+        if pat.match(name.lower()):
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tags["ref:usfs"] = f"FR {name.title()}"
+            matched = True
+
+        pat = re.compile(f"fire road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f"county road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref"] = f"CR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f"fs road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f"fr road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f"usfs road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f".*forest service road")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            if len(tmp) == 3:
+                tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            elif len(tmp) == 4:
+                tags["ref:usfs"] = f"FR {tmp[3].title()}"
+            matched = True
+
+        pat = re.compile(f"fr ")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tags["ref:usfs"] = f"FR {tmp[1].title()}"
+            matched = True
+
+        pat = re.compile(f"fs ")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] =  f"FR {tmp[1].title()}"
+            matched = True
+
+        pat = re.compile(f"usfs trail ")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+            matched = True
+
+        pat = re.compile(f".*fsr{ref}")
+        if pat.match(name.lower()) and not matched:
+            # log.debug(f"MATCHED: {pat.pattern}")
+            tmp = name.split(' ')
+            tags["ref:usfs"] = f"FR {tmp[2].title()}"
+
+        if matched:
+            for key, value in tags.items():
+                if value is not None:
+                    if "properties" in feature:
+                        del feature["properties"]["name"]
+                        feature["properties"][key] = value
+                    elif "tags" in feature:
+                        if "name" in feature["tags"]:
+                            del feature["tags"]["name"]
+                        feature["tags"][key] = value
+            features.append(feature)
+        else:
+            features.append(feature)
+
+        # log.debug(f"\t{tags}")
+
+    if path.suffix == ".geojson":
+        outdata = FeatureCollection(features)
+        file = open(args.outfile, "w")
+        geojson.dump(outdata, file)
+        file.close()
+        log.info(f"Wrote {args.outfile}")
+    else:
+        path = Path(args.outfile)
+        outosm = OsmFile(f"{path.stem}.osm")
+        out = list()
+        for entry in features:
+            if "tiger:cfcc" in entry["tags"]:
+                del entry["tags"]["tiger:cfcc"]
+            if "tiger:county" in entry["tags"]:
+                del entry["tags"]["tiger:county"]
+            if "tiger:name_base" in entry["tags"]:
+                del entry["tags"]["tiger:name_base"]
+            if "tiger:name_base_1" in entry["tags"]:
+                del entry["tags"]["tiger:name_base_1"]
+            if "tiger:name_type" in entry["tags"]:
+                del entry["tags"]["tiger:name_type"]
+            if "tiger:name_type_1" in entry["tags"]:
+                del entry["tags"]["tiger:name_type_1"]
+            if "tiger:reviewed" in entry["tags"]:
+                del entry["tags"]["tiger:reviewed"]
+            if "tiger:tlid" in entry["tags"]:
+                del entry["tags"]["tiger:tlid"]
+            if "tiger:source" in entry["tags"]:
+                del entry["tags"]["tiger:source"]
+            if "tiger:separated" in entry["tags"]:
+                del entry["tags"]["tiger:separated"]
+            if "tiger:upload_uuid" in entry["tags"]:
+                del entry["tags"]["tiger:upload_uuid"]
+            if "refs" in entry:
+                out.append(osm.createWay(entry, True))
+            else:
+                out.append(osm.createNode(entry, True))
+        outosm.write(out)
+        log.info(f"Wrote {path.stem}.osm")
+
+
+if __name__ == "__main__":
+    """This is just a hook so this file can be run standlone during development."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())


### PR DESCRIPTION
This improves merging tags between multiple datasets, so the final version contains all the tags. There is also a new utility that scans the datasets for incorrect names and reference numbers common in OSM data, and fixes them into the proper tagging schema used by OSM for remote forest roads.
