### PR TITLE
National Park service boundaries use UNIT_NAME instead of FOREST…

### DIFF
--- a/utilities/tm-splitter.py
+++ b/utilities/tm-splitter.py
@@ -223,6 +223,8 @@ async def main():
         for feature in grid['features']:
             if "FORESTNAME" in feature["properties"]:
                 name = feature["properties"]["FORESTNAME"].replace(' ', '_')
+            elif "UNIT_NAME" in feature["properties"]:
+                name = feature["properties"]["UNIT_NAME"].replace(' ', '_').replace('/', '_')
             else:
                 name = f"{path.stem}_{index}"
                 index += 1


### PR DESCRIPTION
The tm-splitter utility for splitting multipolygons into separate files needs to use UNIT_NAME instead of FORESTNAME for National Parks. These files are used to split huge project AOIs into smaller files using ogr2ogr.